### PR TITLE
Add support for outputType `var`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,16 @@ module.exports = babelTransform
 // https://github.com/babel/gulp-babel/blob/master/license
 function babelTransform(opts, helperPath, dest){
 
-  var helpers = [];
+  var helpers = [],
+    helperOpts,
+    outputType;
 
   opts = opts || {};
   
-  if(opts.babelHelpers === undefined) {
-    opts.babelHelpers = {};
-  }
+  helperOpts = opts.babelHelpers || {};
+  delete opts.babelHelpers;
+  
+  outputType = helperOpts.outputType || 'umd';
 
   return through.obj(function transpile(file, enc, cb) {
     var res;
@@ -44,8 +47,8 @@ function babelTransform(opts, helperPath, dest){
         helpers.push(helper)
       })
 
-      if ( res.usedHelpers.length )
-        res.code = insertHelperRequire(file, res.code, helperPath)
+      if ( res.usedHelpers.length && outputType === 'umd')
+        res.code = insertHelperRequire(file, res.code, helperPath, outputType)
 
       file.contents = new Buffer(res.code)
 
@@ -63,7 +66,7 @@ function babelTransform(opts, helperPath, dest){
     if ( !helpers.length ) 
       return cb()
 
-    var str = babel.buildExternalHelpers(helpers, opts.babelHelpers.outputType || 'umd');
+    var str = babel.buildExternalHelpers(helpers, outputType);
 
     try {
       fs.writeFileSync(dest, str) //async didn't work...

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ function babelTransform(opts, helperPath, dest){
   var helpers = [];
 
   opts = opts || {};
+  
+  if(opts.babelHelpers === undefined) {
+    opts.babelHelpers = {};
+  }
 
   return through.obj(function transpile(file, enc, cb) {
     var res;
@@ -59,7 +63,7 @@ function babelTransform(opts, helperPath, dest){
     if ( !helpers.length ) 
       return cb()
 
-    var str = babel.buildExternalHelpers(helpers, 'umd');
+    var str = babel.buildExternalHelpers(helpers, opts.babelHelpers.outputType || 'umd');
 
     try {
       fs.writeFileSync(dest, str) //async didn't work...


### PR DESCRIPTION
This add supports for outputType `var`. It still defaults to umd, but if the `opts` object has a `babelHelpers` key with `outputType` defined, it uses that outputType.
